### PR TITLE
lj_potential: use numpy array operations

### DIFF
--- a/src/moxel/utils.py
+++ b/src/moxel/utils.py
@@ -216,14 +216,15 @@ class Grid:
 
         energy = 0
         if len(neighbors) != 0:
-            for atom in neighbors:
-                r_ij = np.linalg.norm(cartesian_coords - atom.coords)
-                if r_ij <= 1e-3:
-                    energy += 1000
-                else:
-                    e_j, s_j = lj_params[atom.species_string]
-                    x = (0.5 * (s_j + self.sigma)) / r_ij
-                    energy += 4 * np.sqrt(e_j * self.epsilon) * (x**12 - x**6)
+            neigh_coords = np.stack([atom.coords for atom in neighbors])
+            r_ij = np.linalg.norm(cartesian_coords - neigh_coords, axis=1)
+            if np.any(r_ij < 1e-3):
+                return 0.
+
+            es_j = np.array([lj_params[atom.species_string] for atom in neighbors])
+            x = (0.5 * (es_j[:,1] + self.sigma)) / r_ij
+            e = 4 * np.sqrt(es_j[:,0] * self.epsilon)
+            energy = sum(e * (x**12 - x**6))
 
         return np.exp(-(1 / 298) * energy) # For numerical stability.
 

--- a/src/moxel/utils.py
+++ b/src/moxel/utils.py
@@ -218,6 +218,13 @@ class Grid:
             cartesian_coords = self._simulation_box.lattice.get_cartesian_coords(coords)
 
         _, r_ij, indices, _ = self._simulation_box._lattice.get_points_in_sphere(self._frac_coords, cartesian_coords, self.cutoff, zip_results=False)
+
+        # No neighbor, zero energy
+        # Need to check for length of r_ij because of https://github.com/materialsproject/pymatgen/issues/3794
+        if len(r_ij) == 0:
+            return 1.
+
+        # Close contact, infinite energy
         if np.any(r_ij < 1e-3):
             return 0.
 

--- a/src/moxel/utils.py
+++ b/src/moxel/utils.py
@@ -183,6 +183,9 @@ class Grid:
         if potential == 'lj':
             # Cache LJ parameters for all atoms in the simulation box
             self._lj_params = np.array([lj_params[atom.species_string] for atom in self._simulation_box])
+            # Cache fractional coordinates, since this is a slow function in pymatgen
+            self._frac_coords = self._simulation_box.frac_coords
+
             # Embarrassingly parallel.
             with Pool(processes=None) as p:
                 energies = list(
@@ -214,7 +217,7 @@ class Grid:
         else:
             cartesian_coords = self._simulation_box.lattice.get_cartesian_coords(coords)
 
-        _, r_ij, indices, _ = self._simulation_box._lattice.get_points_in_sphere(self._simulation_box.frac_coords, cartesian_coords, self.cutoff, zip_results=False)
+        _, r_ij, indices, _ = self._simulation_box._lattice.get_points_in_sphere(self._frac_coords, cartesian_coords, self.cutoff, zip_results=False)
         if np.any(r_ij < 1e-3):
             return 0.
 

--- a/src/moxel/utils.py
+++ b/src/moxel/utils.py
@@ -181,6 +181,8 @@ class Grid:
             self._simulation_box = self.structure * scale
         
         if potential == 'lj':
+            # Cache LJ parameters for all atoms in the simulation box
+            self._lj_params = np.array([lj_params[atom.species_string] for atom in self._simulation_box])
             # Embarrassingly parallel.
             with Pool(processes=None) as p:
                 energies = list(
@@ -209,21 +211,17 @@ class Grid:
         """
         if self.cubic_box:
             cartesian_coords = coords
-            neighbors = self._simulation_box.get_sites_in_sphere(coords, self.cutoff)
         else:
             cartesian_coords = self._simulation_box.lattice.get_cartesian_coords(coords)
-            neighbors = self._simulation_box.get_sites_in_sphere(cartesian_coords, self.cutoff)
 
-        energy = 0
-        if len(neighbors) != 0:
-            r_ij = np.stack([atom.nn_distance for atom in neighbors])
-            if np.any(r_ij < 1e-3):
-                return 0.
+        _, r_ij, indices, _ = self._simulation_box._lattice.get_points_in_sphere(self._simulation_box.frac_coords, cartesian_coords, self.cutoff, zip_results=False)
+        if np.any(r_ij < 1e-3):
+            return 0.
 
-            es_j = np.array([lj_params[atom.species_string] for atom in neighbors])
-            x = (0.5 * (es_j[:,1] + self.sigma)) / r_ij
-            e = 4 * np.sqrt(es_j[:,0] * self.epsilon)
-            energy = sum(e * (x**12 - x**6))
+        es_j = self._lj_params[indices]
+        x = (0.5 * (es_j[:,1] + self.sigma)) / r_ij
+        e = 4 * np.sqrt(es_j[:,0] * self.epsilon)
+        energy = sum(e * (x**12 - x**6))
 
         return np.exp(-(1 / 298) * energy) # For numerical stability.
 

--- a/src/moxel/utils.py
+++ b/src/moxel/utils.py
@@ -216,8 +216,7 @@ class Grid:
 
         energy = 0
         if len(neighbors) != 0:
-            neigh_coords = np.stack([atom.coords for atom in neighbors])
-            r_ij = np.linalg.norm(cartesian_coords - neigh_coords, axis=1)
+            r_ij = np.stack([atom.nn_distance for atom in neighbors])
             if np.any(r_ij < 1e-3):
                 return 0.
 


### PR DESCRIPTION
numpy array operations are faster, so coerce necessary data into numpy arrays and avoid doing math or linalg operations inside Python loops.

Tested on a representative MOF (QETBUP_clean.cif) on my system, with all default parameters: the wall time goes down from 5.89 s to 4.86 s, so that's 17% faster. Voxel statistics are otherwise identical.